### PR TITLE
BUG: Rename Module to IOFDF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,3 @@
-project(ITKIOFDF)
-set(ITKIOFDF_LIBRARIES ITKIOFDF)
+project(IOFDF)
+set(IOFDF_LIBRARIES IOFDF)
 itk_module_impl()

--- a/include/itkFDFImageIO.h
+++ b/include/itkFDFImageIO.h
@@ -17,7 +17,7 @@
 
 #ifndef __itkFDFImageIO_h
 #define __itkFDFImageIO_h
-#include "ITKIOFDFExport.h"
+#include "IOFDFExport.h"
 #include "itkImageIOBase.h"
 
 namespace itk
@@ -28,7 +28,7 @@ namespace itk
  * \ingroup IOFilters
  *
  */
-class ITKIOFDF_EXPORT FDFImageIO : public ImageIOBase
+class IOFDF_EXPORT FDFImageIO : public ImageIOBase
 {
 public:
   /** Standard class typedefs. */

--- a/include/itkFDFImageIOFactory.h
+++ b/include/itkFDFImageIOFactory.h
@@ -16,7 +16,7 @@
  */
 #ifndef __itkFDFImageIOFactory_h
 #define __itkFDFImageIOFactory_h
-#include "ITKIOFDFExport.h"
+#include "IOFDFExport.h"
 #include "itkObjectFactoryBase.h"
 #include "itkImageIOBase.h"
 
@@ -26,7 +26,7 @@ namespace itk
  *  \ingroup ITKIOFDF
  * \brief Create instances of FDFImageIO objects using an object factory.
  */
-class ITKIOFDF_EXPORT FDFImageIOFactory : public ObjectFactoryBase
+class IOFDF_EXPORT FDFImageIOFactory : public ObjectFactoryBase
 {
 public:  
   /** Standard class typedefs. */

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -1,7 +1,7 @@
 set(DOCUMENTATION "This modules contains an ImageIO class to read or write the
 FDF image format.")
 
-itk_module(ITKIOFDF
+itk_module(IOFDF
   ENABLE_SHARED
   DEPENDS
     ITKNIFTI

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,9 @@
-set(ITKIOFDF_SRC
+set(IOFDF_SRC
   itkFDFImageIO.cxx
   itkFDFCommonImageIO.cxx
   itkFDFImageIOFactory.cxx)
 
-add_library(ITKIOFDF ${ITKIOFDF_SRC})
+add_library(IOFDF ${IOFDF_SRC})
 
-target_link_libraries(ITKIOFDF ${ITKIOImageBase_LIBRARIES} ${ITKTransform_LIBRARIES})
-itk_module_target(ITKIOFDF)
+target_link_libraries(IOFDF ${ITKIOImageBase_LIBRARIES} ${ITKTransform_LIBRARIES})
+itk_module_target(IOFDF)

--- a/src/itkFDFImageIOFactory.cxx
+++ b/src/itkFDFImageIOFactory.cxx
@@ -54,7 +54,7 @@ FDFImageIOFactory::GetDescription() const
 
 static bool FDFImageIOFactoryHasBeenRegistered;
 
-void ITKIOFDF_EXPORT FDFImageIOFactoryRegister__Private(void)
+void IOFDF_EXPORT FDFImageIOFactoryRegister__Private(void)
 {
   if( ! FDFImageIOFactoryHasBeenRegistered )
     {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,10 +1,10 @@
 itk_module_test()
-set(ITKIOFDFTests
+set(IOFDFTests
   itkFDFImageIOTest.cxx
 )
 
-CreateTestDriver(ITKIOFDF "${ITKIOFDF-Test_LIBRARIES}" "${ITKIOFDFTests}")
+CreateTestDriver(IOFDF "${IOFDF-Test_LIBRARIES}" "${IOFDFTests}")
 
 itk_add_test(NAME itkFDFImageIOTest
-  COMMAND ITKIOFDFTestDriver itkFDFImageIOTest
+  COMMAND IOFDFTestDriver itkFDFImageIOTest
   ${ITK_TEST_OUTPUT_DIR} ${CMAKE_CURRENT_LIST_DIR}/test.fdf)


### PR DESCRIPTION
The modules name is inconsistent and causing not to be used as a
module in ITK. Previously ITK was calling itk FDFImageIO, while
internally it was called ITKFDFImageIO. Neither name followed ITK
conventions. The correct name for an external module does not begin
with the ITK prefix and for this case should be: IOFDF

The name of the module and related variable, libraries, export
specifications etc, have been rename consistently.
