### PR TITLE
BUG: Correct test function signature for windows

### DIFF
--- a/test/itkFDFImageIOTest.cxx
+++ b/test/itkFDFImageIOTest.cxx
@@ -6,7 +6,7 @@
 
 #include "itkImage.h"
 
-int itkFDFImageIOTest( int argc, char ** argv )
+int itkFDFImageIOTest( int argc, char * argv[] )
 {
   if(argc < 3)
     {


### PR DESCRIPTION
This patch addresses the following compilation error on windows:
IOFDFTestDriver.cxx.obj : error LNK2001: unresolved external symbol "int __cdecl itkFDFImageIOTest(int,char * * const)" (?itkFDFImageIOTest@@YAHHQEAPEAD@Z)