### PR TITLE
BUG: Ensure factory is registered once.

### DIFF
--- a/include/itkFDFImageIOFactory.h
+++ b/include/itkFDFImageIOFactory.h
@@ -50,7 +50,7 @@ public:
   static void RegisterOneFactory(void)
   {
     FDFImageIOFactory::Pointer FdfFactory = FDFImageIOFactory::New();
-    ObjectFactoryBase::RegisterFactory(FdfFactory);
+    ObjectFactoryBase::RegisterFactoryInternal(FdfFactory);
   }
 
 protected:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,7 @@ set(IOFDF_SRC
   itkFDFCommonImageIO.cxx
   itkFDFImageIOFactory.cxx)
 
-add_library(IOFDF ${IOFDF_SRC})
+add_library(IOFDF ${ITK_LIBRARY_BUILD_TYPE} ${IOFDF_SRC})
 
 target_link_libraries(IOFDF ${ITKIOImageBase_LIBRARIES} ${ITKTransform_LIBRARIES})
 itk_module_target(IOFDF)


### PR DESCRIPTION
This commit updates CMakeLists.txt to ensure built library is shared. It
also uses "RegisterFactoryInternal" to make sure the factory is
registered once into the ImageIOFactory.

See InsightSoftwareConsortium/ITK@39b4ab3 (BUG: Internal factory must
use RegisterFactoryInternal method) for more details.

See ITK issue #3393
https://issues.itk.org/jira/browse/ITK-3393