### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkFDFImageIO.h
+++ b/include/itkFDFImageIO.h
@@ -34,6 +34,8 @@ namespace itk
 class IOFDF_EXPORT FDFImageIO : public ImageIOBase
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(FDFImageIO);
+
   /** Standard class type alias. */
   using Self = FDFImageIO;
   using Superclass = ImageIOBase;
@@ -105,8 +107,6 @@ protected:
   int ReadHeader(const char *FileNameToRead);
 
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(FDFImageIO);
-
   void SwapBytesIfNecessary(void* buffer, unsigned long numberOfPixels);
 
   // Position after ReadImageInformation.

--- a/include/itkFDFImageIOFactory.h
+++ b/include/itkFDFImageIOFactory.h
@@ -30,6 +30,8 @@ namespace itk
 class IOFDF_EXPORT FDFImageIOFactory : public ObjectFactoryBase
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(FDFImageIOFactory);
+
   /** Standard class type alias. */
   using Self = FDFImageIOFactory;
   using Superclass = ObjectFactoryBase;
@@ -56,10 +58,6 @@ public:
 protected:
   FDFImageIOFactory();
   ~FDFImageIOFactory() override;
-
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(FDFImageIOFactory);
-
 };
 
 


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.