### PR TITLE
DOC: Improve Python package information.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     package_dir={'itk': 'itk'},
     download_url=r'https://github.com/InsightSoftwareConsortium/ITKFDFImageIO',
     description=r'ITK `ImageIO` class to read or write the FDF image format',
-    long_description='itkFDFImageIO provides an `ImageIO` class to read or'
+    long_description='itk-fdfimageio provides an `ImageIO` class to read or '
                      'write the FDF image format.',
     classifiers=[
         "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
Improve Python package information:
- Make the reference in the long description match the package name and
  not the ITK project name.
- Use white spaces to avoid words in two consecutive lines being
  concatenated.

Partially addresses:
https://github.com/InsightSoftwareConsortium/ITK/issues/326