### PR TITLE
ENH: Modernize CMake to use itk_module_add_library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,7 +3,5 @@ set(IOFDF_SRC
   itkFDFCommonImageIO.cxx
   itkFDFImageIOFactory.cxx)
 
-add_library(IOFDF ${ITK_LIBRARY_BUILD_TYPE} ${IOFDF_SRC})
+itk_module_add_library(IOFDF ${IOFDF_SRC})
 
-target_link_libraries(IOFDF ${ITKIOImageBase_LIBRARIES} ${ITKTransform_LIBRARIES})
-itk_module_target(IOFDF)


### PR DESCRIPTION
Replace add_library with itk_module_add_library macro for better integration with ITK module system. This provides automatic dependency linking, include directory setup, and consistent target naming.